### PR TITLE
chore: update docs to include correct destructure usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install --save mutable-buffer
 ## Usage
 
 ```js
-var MutableBuffer = require('mutable-buffer');
+var { MutableBuffer } = require('mutable-buffer');
 
 var buffer = new MutableBuffer(/* initialSize, blockSize */);
 var result;


### PR DESCRIPTION
`MutableBuffer` is not exported as a default, however, in the docs it appears as if it is a default export. We should change the docs to show correct usage for other developers.